### PR TITLE
Obtain max_zcoord from spider and update modify script

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,5 @@ symlink_path "$(realpath ~)/.local/share/QGIS/QGIS3/profiles/pdokplugin-develop/
 mkdir -p $(dirname "$symlink_path")
 ln -s "$(pwd)/pdokservicesplugin" "$symlink_path" # uitvoeren vanuit root van repo
 ```
+
+# TODO: document modify-layers-pdok-ogcapi.py

--- a/README.md
+++ b/README.md
@@ -95,4 +95,4 @@ mkdir -p $(dirname "$symlink_path")
 ln -s "$(pwd)/pdokservicesplugin" "$symlink_path" # uitvoeren vanuit root van repo
 ```
 
-# TODO: document modify-layers-pdok-ogcapi.py
+Extend the layers config file using OGC:API urls, see [`scripts/modify-layers-pdok-ogcapi.py`](scripts/modify-layers-pdok-ogcapi.py) for more detailed instructions.

--- a/pdokservicesplugin/pdokservicesplugin.py
+++ b/pdokservicesplugin/pdokservicesplugin.py
@@ -474,7 +474,11 @@ class PdokServicesPlugin(object):
                     # We disable all options that do not support correct projection of vector tiles
                     self.dlg.ui.comboSelectProj.model().item(i).setEnabled(False)
                     self.dlg.ui.comboSelectProj.setToolTip(
-                        f"""OGC API - Tiles wordt momenteel alleen correct weergegeven in webmercator CRS (EPSG:3857). Het gebruik van andere CRS zorgt momenteel voor foutieve projecties. Zie: https://github.com/qgis/QGIS/issues/54673"""
+                        f"""
+                        OGC API - Tiles wordt momenteel alleen correct weergegeven in webmercator CRS (EPSG:3857). 
+                        Het gebruik van andere CRS zorgt momenteel voor foutieve projecties. 
+                        Zie: https://github.com/qgis/QGIS/issues/54673
+                        """
                     )
 
     def extract_crs(self, crs_string):
@@ -534,99 +538,17 @@ class PdokServicesPlugin(object):
         url = self.current_layer["service_url"]
 
         if servicetype == "wms":
-            imgformat = self.current_layer["imgformats"].split(",")[0]
-            crs = self.get_crs_comboselect()
-
-            selected_style_name = ""
-            if "selectedStyle" in self.current_layer:
-                selected_style = self.current_layer["selectedStyle"]
-            else:
-                selected_style = self.get_selected_style()
-            if selected_style is not None:
-                selected_style_name = selected_style["name"]
-                selected_style_title = selected_style["name"]
-                if "title" in selected_style:
-                    selected_style_title = selected_style["title"]
-                title += f" [{selected_style_title}]"
-
-            uri = f"crs={crs}&layers={layername}&styles={selected_style_name}&format={imgformat}&url={url}"
-            return QgsRasterLayer(uri, title, "wms")
+            return self.create_wms_layer(layername, title, url)
         elif servicetype == "wmts":
-            if Qgis.QGIS_VERSION_INT < 10900:
-                self.show_warning(
-                    f"""Sorry, dit type layer: '{servicetype.upper()}'
-                    kan niet worden geladen in deze versie van QGIS.
-                    Misschien kunt u QGIS 2.0 installeren (die kan het WEL)?
-                    Of is de laag niet ook beschikbaar als wms of wfs?"""
-                )
-                return None
-            url = self.quote_wmts_url(url)
-            tilematrixset = self.get_crs_comboselect()
-
-            imgformat = self.current_layer["imgformats"].split(",")[0]
-            if tilematrixset.startswith("EPSG:"):
-                crs = tilematrixset
-                i = crs.find(":", 5)
-                if i > -1:
-                    crs = crs[:i]
-            elif tilematrixset.startswith("OGC:1.0"):
-                crs = "EPSG:3857"
-            uri = f"tileMatrixSet={tilematrixset}&crs={crs}&layers={layername}&styles=default&format={imgformat}&url={url}"
-            return QgsRasterLayer(
-                uri, title, "wms"
-            )  # `wms` is correct, zie ook quote_wmts_url
+            return self.create_wmts_layer(layername, title, url, servicetype)
         elif servicetype == "wfs":
-            uri = f" pagingEnabled='true' restrictToRequestBBOX='1' srsname='EPSG:28992' typename='{layername}' url='{url}' version='2.0.0'"
-            return QgsVectorLayer(uri, title, "wfs")
+            return self.create_wfs_layer(layername, title, url)
         elif servicetype == "wcs":
-            # HACK to get WCS to work:
-            # 1) fixed format to "GEOTIFF"
-            # 2) remove the '?request=getcapabiliteis....' part from the url, unknown why this is required compared to wms/wfs
-            # better approach would be to add the supported format(s) to the layers-pdok.json file and use that - this should be the approach when more
-            # WCS services will be published by PDOK (currently it is only the AHN WCS)
-            format = "GEOTIFF"
-            uri = f"cache=AlwaysNetwork&crs=EPSG:28992&format={format}&identifier={layername}&url={url.split('?')[0]}"
-            return QgsRasterLayer(uri, title, "wcs")
+            return self.create_wcs_layer(layername, title, url)
         elif servicetype == "api features":
-            uri = f" pagingEnabled='true' restrictToRequestBBOX='1' preferCoordinatesForWfsT11='false' typename='{layername}' url='{url}'"
-            return QgsVectorLayer(uri, title, "OAPIF")
+            return self.create_oaf_layer(layername, title, url)
         elif servicetype == "api tiles":
-            # CRS does not work as expected in qgis/gdal. We can set a crs (non-webmercator), but it is rendered incorrectly.
-            crs = self.get_crs_comboselect()
-            used_tileset = [
-                tileset
-                for tileset in self.current_layer["tiles"][0]["tilesets"]
-                if tileset["tileset_crs"].endswith(crs.split(":")[1])
-            ][0]
-
-            # Style toevoegen in laag vanuit ui
-            selected_style = self.get_selected_style()
-            selected_style_url = ""
-
-            if selected_style is not None:
-                selected_style_url = selected_style["url"]
-                title += f" [{selected_style['name']}]"
-
-            url_template = (
-                url
-                + "/tiles/"
-                + used_tileset["tileset_id"]
-                + "/%7Bz%7D/%7By%7D/%7Bx%7D?f%3Dmvt"
-            )
-            maxz_coord = used_tileset["tileset_max_zoomlevel"]
-
-            # Although the vector tiles are only rendered for a specific zoom-level @PDOK (see maxz_coord),
-            # we need to set the minimum z value to 1, which gives better performance, see https://github.com/qgis/QGIS/issues/54312
-            minz_coord = 1
-
-            type = "xyz"
-            uri = f"styleUrl={selected_style_url}&url={url_template}&type={type}&zmax={maxz_coord}&zmin={minz_coord}&http-header:referer="
-            tile_layer = QgsVectorTileLayer(uri, title)
-
-            # Set the VT layer CRS and load the styleUrl
-            tile_layer.setCrs(srs=QgsCoordinateReferenceSystem(crs))
-            tile_layer.loadDefaultStyle()
-            return tile_layer
+            return self.create_oat_layer(title, url)
         else:
             self.show_warning(
                 f"""Sorry, dit type laag: '{servicetype.upper()}'
@@ -635,6 +557,106 @@ class PdokServicesPlugin(object):
                 """
             )
             return
+
+    def create_wms_layer(self, layername, title, url):
+        imgformat = self.current_layer["imgformats"].split(",")[0]
+        crs = self.get_crs_comboselect()
+
+        selected_style_name = ""
+        if "selectedStyle" in self.current_layer:
+            selected_style = self.current_layer["selectedStyle"]
+        else:
+            selected_style = self.get_selected_style()
+        if selected_style is not None:
+            selected_style_name = selected_style["name"]
+            selected_style_title = selected_style["name"]
+            if "title" in selected_style:
+                selected_style_title = selected_style["title"]
+            title += f" [{selected_style_title}]"
+
+        uri = f"crs={crs}&layers={layername}&styles={selected_style_name}&format={imgformat}&url={url}"
+        return QgsRasterLayer(uri, title, "wms")
+
+    def create_wmts_layer(self, layername, title, url, servicetype):
+        if Qgis.QGIS_VERSION_INT < 10900:
+            self.show_warning(
+                f"""Sorry, dit type layer: '{servicetype.upper()}'
+                kan niet worden geladen in deze versie van QGIS.
+                Misschien kunt u QGIS 2.0 installeren (die kan het WEL)?
+                Of is de laag niet ook beschikbaar als wms of wfs?"""
+            )
+            return None
+        url = self.quote_wmts_url(url)
+        tilematrixset = self.get_crs_comboselect()
+
+        imgformat = self.current_layer["imgformats"].split(",")[0]
+        if tilematrixset.startswith("EPSG:"):
+            crs = tilematrixset
+            i = crs.find(":", 5)
+            if i > -1:
+                crs = crs[:i]
+        elif tilematrixset.startswith("OGC:1.0"):
+            crs = "EPSG:3857"
+        uri = f"tileMatrixSet={tilematrixset}&crs={crs}&layers={layername}&styles=default&format={imgformat}&url={url}"
+        return QgsRasterLayer(
+            uri, title, "wms"
+        )  # `wms` is correct, zie ook quote_wmts_url
+
+    def create_wfs_layer(self, layername, title, url):
+        uri = f" pagingEnabled='true' restrictToRequestBBOX='1' srsname='EPSG:28992' typename='{layername}' url='{url}' version='2.0.0'"
+        return QgsVectorLayer(uri, title, "wfs")
+
+    def create_wcs_layer(self, layername, title, url):
+        # HACK to get WCS to work:
+        # 1) fixed format to "GEOTIFF"
+        # 2) remove the '?request=getcapabiliteis....' part from the url, unknown why this is required compared to wms/wfs
+        # better approach would be to add the supported format(s) to the layers-pdok.json file and use that - this should be the approach when more
+        # WCS services will be published by PDOK (currently it is only the AHN WCS)
+        format = "GEOTIFF"
+        uri = f"cache=AlwaysNetwork&crs=EPSG:28992&format={format}&identifier={layername}&url={url.split('?')[0]}"
+        return QgsRasterLayer(uri, title, "wcs")
+
+    def create_oaf_layer(self, layername, title, url):
+        uri = f" pagingEnabled='true' restrictToRequestBBOX='1' preferCoordinatesForWfsT11='false' typename='{layername}' url='{url}'"
+        return QgsVectorLayer(uri, title, "OAPIF")
+
+    def create_oat_layer(self, title, url):
+        # CRS does not work as expected in qgis/gdal. We can set a crs (non-webmercator), but it is rendered incorrectly.
+        crs = self.get_crs_comboselect()
+        used_tileset = [
+            tileset
+            for tileset in self.current_layer["tiles"][0]["tilesets"]
+            if tileset["tileset_crs"].endswith(crs.split(":")[1])
+        ][0]
+
+        # Style toevoegen in laag vanuit ui
+        selected_style = self.get_selected_style()
+        selected_style_url = ""
+
+        if selected_style is not None:
+            selected_style_url = selected_style["url"]
+            title += f" [{selected_style['name']}]"
+
+        url_template = (
+            url
+            + "/tiles/"
+            + used_tileset["tileset_id"]
+            + "/%7Bz%7D/%7By%7D/%7Bx%7D?f%3Dmvt"
+        )
+        maxz_coord = used_tileset["tileset_max_zoomlevel"]
+
+        # Although the vector tiles are only rendered for a specific zoom-level @PDOK (see maxz_coord),
+        # we need to set the minimum z value to 1, which gives better performance, see https://github.com/qgis/QGIS/issues/54312
+        minz_coord = 1
+
+        type = "xyz"
+        uri = f"styleUrl={selected_style_url}&url={url_template}&type={type}&zmax={maxz_coord}&zmin={minz_coord}&http-header:referer="
+        tile_layer = QgsVectorTileLayer(uri, title)
+
+        # Set the VT layer CRS and load the styleUrl
+        tile_layer.setCrs(srs=QgsCoordinateReferenceSystem(crs))
+        tile_layer.loadDefaultStyle()
+        return tile_layer
 
     def load_layer(self, tree_location=None):
         if self.current_layer == None:

--- a/pdokservicesplugin/pdokservicesplugin.py
+++ b/pdokservicesplugin/pdokservicesplugin.py
@@ -627,12 +627,7 @@ class PdokServicesPlugin(object):
                 + used_tileset["tileset_id"]
                 + "/%7Bz%7D/%7By%7D/%7Bx%7D?f%3Dmvt"
             )
-            if crs == "EPSG:28992":
-                maxz_coord = 12
-            elif crs == "EPSG:4258" or crs == "EPSG:3035":
-                maxz_coord = 14
-            else:
-                maxz_coord = 17
+            maxz_coord = used_tileset["tileset_max_zoomlevel"]
             minz_coord = 1
             # Although the vector tiles are only rendered for a specific zoom-level @PDOK (see maxz_coord),
             # we need to set the minimum z value to 1, which gives better performance, see https://github.com/qgis/QGIS/issues/54312

--- a/pdokservicesplugin/pdokservicesplugin.py
+++ b/pdokservicesplugin/pdokservicesplugin.py
@@ -445,33 +445,31 @@ class PdokServicesPlugin(object):
             )
 
         if stype == "WMS":
-            try:
-                crs = self.current_layer["crs"]
-            except KeyError:
-                crs = "EPSG:28992"
+            crs = self.current_layer.get("crs", "EPSG:28992")
             crs = crs.split(",")
             self.dlg.ui.comboSelectProj.addItems(crs)
-            for i in range(len(crs)):
-                if crs[i] == "EPSG:28992":
+            for i, c in enumerate(crs):
+                if c == "EPSG:28992":
                     self.dlg.ui.comboSelectProj.setCurrentIndex(i)
 
         elif stype == "WMTS":
             tilematrixsets = self.current_layer["tilematrixsets"].split(",")
             self.dlg.ui.comboSelectProj.addItems(tilematrixsets)
-            for i in range(len(tilematrixsets)):
-                if tilematrixsets[i].startswith("EPSG:28992"):
+            for i, tilematrixset in enumerate(tilematrixsets):
+                if tilematrixset.startswith("EPSG:28992"):
                     self.dlg.ui.comboSelectProj.setCurrentIndex(i)
 
         elif stype == "OGC API - Tiles":
             tiles = self.current_layer["tiles"][0]
-            crs_list = []
-            try:
-                crs_list = [tileset["tileset_crs"] for tileset in tiles["tilesets"]]
-            except KeyError:
-                crs_list = ["EPSG:3857"]
-            self.dlg.ui.comboSelectProj.addItems(map(self.extract_crs, crs_list))
-            for i in range(len(crs_list)):
-                if crs_list[i].split("/")[-1] == "3857":
+            crs_list = list(
+                {
+                    self.extract_crs(tileset.get("tileset_crs", "EPSG:3857"))
+                    for tileset in tiles["tilesets"]
+                }
+            )
+            self.dlg.ui.comboSelectProj.addItems(crs_list)
+            for i, crs in enumerate(crs_list):
+                if crs.split("/")[-1] == "3857":
                     self.dlg.ui.comboSelectProj.setCurrentIndex(i)
                     self.dlg.ui.comboSelectProj.model().item(i).setEnabled(True)
                 else:
@@ -594,51 +592,49 @@ class PdokServicesPlugin(object):
             format = "GEOTIFF"
             uri = f"cache=AlwaysNetwork&crs=EPSG:28992&format={format}&identifier={layername}&url={url.split('?')[0]}"
             return QgsRasterLayer(uri, title, "wcs")
-        elif servicetype == "api features":  # OGC API Features
+        elif servicetype == "api features":
             uri = f" pagingEnabled='true' restrictToRequestBBOX='1' preferCoordinatesForWfsT11='false' typename='{layername}' url='{url}'"
             return QgsVectorLayer(uri, title, "OAPIF")
-        elif servicetype == "api tiles":  # OGC API Tiles
+        elif servicetype == "api tiles":
             # CRS does not work as expected in qgis/gdal. We can set a crs (non-webmercator), but it is rendered incorrectly.
             crs = self.get_crs_comboselect()
-            tiles = self.current_layer["tiles"][0]
-            tilesets = tiles["tilesets"]
-            used_tileset = next(
-                (
-                    tileset
-                    for tileset in tilesets
-                    if tileset["tileset_crs"].endswith(crs.split(":")[1])
-                ),
-                None,
-            )
+            used_tilesets = [
+                tileset
+                for tileset in self.current_layer["tiles"][0]
+                if tileset["tileset_crs"].endswith(self.extract_crs(crs))
+            ]
 
-            # Style toevoegen in laag vanuit ui
-            selected_style_name = (
-                self.current_layer["default"] if "default" in self.current_layer else ""
-            )
-            selected_style = self.get_selected_style()
-            if selected_style is not None:
-                selected_style_name = selected_style["name"]
-                selected_style_url = selected_style["url"]
-                title += f" [{selected_style_name}]"
+            if used_tilesets:
+                used_tileset = used_tilesets[0]
+                # Style toevoegen in laag vanuit ui
+                selected_style = self.get_selected_style()
+                if selected_style is not None:
+                    selected_style_url = selected_style["url"]
+                    title += f" [{selected_style['name']}]"
+                else:
+                    # TODO: selected style can be None?
+                    raise ValueError("TODO: handle style not selected")
 
-            url_template = (
-                url
-                + "/tiles/"
-                + used_tileset["tileset_id"]
-                + "/%7Bz%7D/%7By%7D/%7Bx%7D?f%3Dmvt"
-            )
-            maxz_coord = used_tileset["tileset_max_zoomlevel"]
-            minz_coord = 1
-            # Although the vector tiles are only rendered for a specific zoom-level @PDOK (see maxz_coord),
-            # we need to set the minimum z value to 1, which gives better performance, see https://github.com/qgis/QGIS/issues/54312
-            type = "xyz"
-            uri = f"styleUrl={selected_style_url}&url={url_template}&type={type}&zmax={maxz_coord}&zmin={minz_coord}&http-header:referer="
-            tile_layer = QgsVectorTileLayer(uri, title)
+                url_template = (
+                    url
+                    + "/tiles/"
+                    + used_tileset["tileset_id"]
+                    + "/%7Bz%7D/%7By%7D/%7Bx%7D?f%3Dmvt"
+                )
+                maxz_coord = used_tileset["tileset_max_zoomlevel"]
 
-            # Set the VT layer CRS and load the styleUrl
-            tile_layer.setCrs(srs=QgsCoordinateReferenceSystem(crs))
-            tile_layer.loadDefaultStyle()
-            return tile_layer
+                # Although the vector tiles are only rendered for a specific zoom-level @PDOK (see maxz_coord),
+                # we need to set the minimum z value to 1, which gives better performance, see https://github.com/qgis/QGIS/issues/54312
+                minz_coord = 1
+
+                type = "xyz"
+                uri = f"styleUrl={selected_style_url}&url={url_template}&type={type}&zmax={maxz_coord}&zmin={minz_coord}&http-header:referer="
+                tile_layer = QgsVectorTileLayer(uri, title)
+
+                # Set the VT layer CRS and load the styleUrl
+                tile_layer.setCrs(srs=QgsCoordinateReferenceSystem(crs))
+                tile_layer.loadDefaultStyle()
+                return tile_layer
         else:
             self.show_warning(
                 f"""Sorry, dit type laag: '{servicetype.upper()}'
@@ -793,7 +789,6 @@ class PdokServicesPlugin(object):
         # userrole is a free form one:
         # only attach the data to the first item
         # service layer = a dict/object with all props of the layer
-
         itemType.setData(serviceLayer, Qt.UserRole)
         itemType.setToolTip(f'{stype} - {serviceLayer["title"]}')
         # only wms services have styles (sometimes)

--- a/pdokservicesplugin/pdokservicesplugin.py
+++ b/pdokservicesplugin/pdokservicesplugin.py
@@ -320,6 +320,7 @@ class PdokServicesPlugin(object):
         url = self.current_layer["service_url"]
         title = self.current_layer["title"]
         abstract_dd = self.get_dd(self.current_layer["abstract"])
+        service_abstract_dd = self.get_dd(self.current_layer["service_abstract"])
 
         service_title = (
             self.current_layer["service_title"]
@@ -327,7 +328,6 @@ class PdokServicesPlugin(object):
             else "[service title niet ingevuld]"
         )
         layername = self.current_layer["name"]
-        service_abstract_dd = self.get_dd(self.current_layer["service_abstract"])
         stype = (
             self.service_type_mapping[self.current_layer["service_type"]]
             if self.current_layer["service_type"] in self.service_type_mapping
@@ -461,25 +461,20 @@ class PdokServicesPlugin(object):
 
         elif stype == "OGC API - Tiles":
             tiles = self.current_layer["tiles"][0]
-            crs_list = list(
-                {
-                    self.extract_crs(tileset.get("tileset_crs", "EPSG:3857"))
-                    for tileset in tiles["tilesets"]
-                }
-            )
+            crs_list = [
+                self.extract_crs(tileset["tileset_crs"])
+                for tileset in tiles["tilesets"]
+            ]
             self.dlg.ui.comboSelectProj.addItems(crs_list)
             for i, crs in enumerate(crs_list):
-                if crs.split("/")[-1] == "3857":
+                if crs.endswith("3857"):
                     self.dlg.ui.comboSelectProj.setCurrentIndex(i)
                     self.dlg.ui.comboSelectProj.model().item(i).setEnabled(True)
                 else:
                     # We disable all options that do not support correct projection of vector tiles
                     self.dlg.ui.comboSelectProj.model().item(i).setEnabled(False)
                     self.dlg.ui.comboSelectProj.setToolTip(
-                        f"""OGC API - Tiles wordt momenteel alleen correct weergegeven in webmercator CRS (EPSG:3857). 
-                Het gebruik van andere CRS zorgt momenteel voor foutieve projecties.
-                Zie: https://github.com/qgis/QGIS/issues/54673  
-                """
+                        f"""OGC API - Tiles wordt momenteel alleen correct weergegeven in webmercator CRS (EPSG:3857). Het gebruik van andere CRS zorgt momenteel voor foutieve projecties. Zie: https://github.com/qgis/QGIS/issues/54673"""
                     )
 
     def extract_crs(self, crs_string):
@@ -598,43 +593,40 @@ class PdokServicesPlugin(object):
         elif servicetype == "api tiles":
             # CRS does not work as expected in qgis/gdal. We can set a crs (non-webmercator), but it is rendered incorrectly.
             crs = self.get_crs_comboselect()
-            used_tilesets = [
+            used_tileset = [
                 tileset
-                for tileset in self.current_layer["tiles"][0]
-                if tileset["tileset_crs"].endswith(self.extract_crs(crs))
-            ]
+                for tileset in self.current_layer["tiles"][0]["tilesets"]
+                if tileset["tileset_crs"].endswith(crs.split(":")[1])
+            ][0]
 
-            if used_tilesets:
-                used_tileset = used_tilesets[0]
-                # Style toevoegen in laag vanuit ui
-                selected_style = self.get_selected_style()
-                if selected_style is not None:
-                    selected_style_url = selected_style["url"]
-                    title += f" [{selected_style['name']}]"
-                else:
-                    # TODO: selected style can be None?
-                    raise ValueError("TODO: handle style not selected")
+            # Style toevoegen in laag vanuit ui
+            selected_style = self.get_selected_style()
+            selected_style_url = ""
 
-                url_template = (
-                    url
-                    + "/tiles/"
-                    + used_tileset["tileset_id"]
-                    + "/%7Bz%7D/%7By%7D/%7Bx%7D?f%3Dmvt"
-                )
-                maxz_coord = used_tileset["tileset_max_zoomlevel"]
+            if selected_style is not None:
+                selected_style_url = selected_style["url"]
+                title += f" [{selected_style['name']}]"
 
-                # Although the vector tiles are only rendered for a specific zoom-level @PDOK (see maxz_coord),
-                # we need to set the minimum z value to 1, which gives better performance, see https://github.com/qgis/QGIS/issues/54312
-                minz_coord = 1
+            url_template = (
+                url
+                + "/tiles/"
+                + used_tileset["tileset_id"]
+                + "/%7Bz%7D/%7By%7D/%7Bx%7D?f%3Dmvt"
+            )
+            maxz_coord = used_tileset["tileset_max_zoomlevel"]
 
-                type = "xyz"
-                uri = f"styleUrl={selected_style_url}&url={url_template}&type={type}&zmax={maxz_coord}&zmin={minz_coord}&http-header:referer="
-                tile_layer = QgsVectorTileLayer(uri, title)
+            # Although the vector tiles are only rendered for a specific zoom-level @PDOK (see maxz_coord),
+            # we need to set the minimum z value to 1, which gives better performance, see https://github.com/qgis/QGIS/issues/54312
+            minz_coord = 1
 
-                # Set the VT layer CRS and load the styleUrl
-                tile_layer.setCrs(srs=QgsCoordinateReferenceSystem(crs))
-                tile_layer.loadDefaultStyle()
-                return tile_layer
+            type = "xyz"
+            uri = f"styleUrl={selected_style_url}&url={url_template}&type={type}&zmax={maxz_coord}&zmin={minz_coord}&http-header:referer="
+            tile_layer = QgsVectorTileLayer(uri, title)
+
+            # Set the VT layer CRS and load the styleUrl
+            tile_layer.setCrs(srs=QgsCoordinateReferenceSystem(crs))
+            tile_layer.loadDefaultStyle()
+            return tile_layer
         else:
             self.show_warning(
                 f"""Sorry, dit type laag: '{servicetype.upper()}'

--- a/scripts/generate-pdok-layers-config.sh
+++ b/scripts/generate-pdok-layers-config.sh
@@ -40,7 +40,7 @@ if [[ $nr_of_services != "-" ]];then
   nr_svc_flag="-n ${nr_of_services}"
 fi
 
-docker run -v "${output_dir}:/output_dir" -v /tmp:/tmp "pdok/ngr-services-spider:0.6.3" layers $nr_svc_flag --snake-case --pretty -s /tmp/sorting-rules.json -m flat -p "OGC:WMS,OGC:WFS,OGC:WCS,OGC:WMTS,OGC:API tiles,OGC:API features" "/output_dir/${output_file_base}" --jq-filter '.layers[] |= with_entries(
+docker run -v "${output_dir}:/output_dir" -v /tmp:/tmp "pdok/ngr-services-spider:0.6.4" layers $nr_svc_flag --snake-case --pretty -s /tmp/sorting-rules.json -m flat -p "OGC:WMS,OGC:WFS,OGC:WCS,OGC:WMTS,OGC:API tiles,OGC:API features" "/output_dir/${output_file_base}" --jq-filter '.layers[] |= with_entries(
   if .key == "service_protocol" then 
     .value = (.value | split(":")[1] | ascii_downcase) | .key = "service_type" 
   elif .key == "service_metadata_id" then 


### PR DESCRIPTION
# Omschrijving

Een omschrijving van wat je hebt toegevoegd/veranderd:

Nav meeting op woensdag 22-11 met Roel & Linda 2 wijzigingen doorgevoerd. 

1. ngr-services-spider geeft per crs (voor ogcapi tiles) ook de maximale z coordinaat mee die meegegeven wordt met een datalaag, zodat deze goed gerenderd wordt.
2. Het modify script werkt nu net iets  anders. Ipv hardcoded een aantal urls, kan nu een lijst aan urls van ogcapi landing pages meegegeven worden aan het script om hier lagen voor toe te voegen in het pdok-layers.json bestand. Als de api zowel tiles als features(collections) bevat, worden deze beide toegevoegd.  
3. (We hebben het generate config script gedraaid met de nieuwe spider)